### PR TITLE
Fix header overlapping the title section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -66,8 +66,9 @@
         </div>
     </nav>
 
+    <div class="h-16"></div>
     <!-- Hero Section with Particle Effects -->
-    <section class="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-primary-50 to-accent-50 pt-16">
+    <section class="relative min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-br from-primary-50 to-accent-50">
         <!-- Animated Background Particles -->
         <div class="absolute inset-0 overflow-hidden">
             <div class="particle absolute w-2 h-2 bg-accent rounded-full opacity-60 animate-pulse" style="top: 20%; left: 10%; animation-delay: 0s;"></div>


### PR DESCRIPTION
This change adds a spacer div to push the content down and removes the top padding from the hero section.